### PR TITLE
Use --limit-rate for non-numeric rate values

### DIFF
--- a/src/gallery_dl_wrapper.py
+++ b/src/gallery_dl_wrapper.py
@@ -28,11 +28,14 @@ def build_command(
     url: str
         Target URL to download from.
     cookies: Optional[str]
-        Path to cookies file for authentication. ``None`` disables cookie usage.
+        Path to cookies file for authentication. ``None`` disables cookie
+        usage.
     download_archive: Optional[str]
         File path for gallery-dl's ``--download-archive``. ``None`` to skip.
     rate_limit: Optional[str]
-        Value for ``--rate-limit`` (e.g. ``"1M"``) or ``--sleep`` (e.g. ``"2"`` seconds).
+        Value for ``--limit-rate`` (e.g. ``"1M"``) or ``--sleep``
+        (e.g. ``"2"`` seconds). Non-numeric values use ``--limit-rate``;
+        numeric values are treated as seconds for ``--sleep``.
         ``None`` to omit.
     extra_args: Optional[Iterable[str]]
         Additional arguments for gallery-dl.
@@ -65,7 +68,7 @@ def build_command(
         if rate_limit.replace(".", "", 1).isdigit():
             command.extend(["--sleep", rate_limit])
         else:
-            command.extend(["--rate-limit", rate_limit])
+            command.extend(["--limit-rate", rate_limit])
     if extra_args:
         command.extend(list(extra_args))
     logger.debug("Built command: %s", command)
@@ -90,7 +93,7 @@ def execute(
     download_archive: Optional[str]
         File path for gallery-dl's ``--download-archive``.
     rate_limit: Optional[str]
-        Value for ``--rate-limit`` or ``--sleep`` depending on format.
+        Value for ``--limit-rate`` or ``--sleep`` depending on format.
     extra_args: Optional[Iterable[str]]
         Additional arguments for gallery-dl.
 


### PR DESCRIPTION
## Summary
- switch to `--limit-rate` when `rate_limit` is non-numeric
- document `--limit-rate` in gallery-dl wrapper docstrings

## Testing
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b084df37d48323a0d8653458b7100d